### PR TITLE
Fixed issue with empty sample gamAppId

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,9 +31,11 @@ android {
 }
 
 androidComponents.onVariants { variant ->
-    variant.manifestPlaceholders.put("gamAppId",
-        providers.gradleProperty("sample_gam_app_id").orElse("ca-app-pub-3940256099942544~3347511713")
-    )
+    val gamAppId = providers.gradleProperty("sample_gam_app_id")
+        .orNull
+        .orEmpty()
+        .ifEmpty { "ca-app-pub-3940256099942544~3347511713" }
+    variant.manifestPlaceholders.put("gamAppId", gamAppId)
 
     /* Other keys that can be configured in the sample app */
     listOf(


### PR DESCRIPTION
1. Fixed issue where if the `sample_gam_app_id` is empty, it correctly defaults to the hardcoded sample gam app id.

If the `sample_gam_app_id` is in the `gradle.properties` but empty (as it is when you clone for the first time), the app simply crashes because `orElse` will simply return an empty string.

2. Fixed issue whereby we were setting the manifest placeholder with an instance of a `Provider<String>` instead of its value.

`providers.gradleProperty("sample_gam_app_id").orElse("ca-app-pub-3940256099942544~3347511713")` returns an instance of `Provider<String>` instead of its value as `String`. So effectively an instance of `Provider<String>` was being put in the `manifestPlaceholders` map, which doesn't sound right.